### PR TITLE
Disable CI variable to prevent warnings from being treated as errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
disable ci warning for now